### PR TITLE
Add exporter and extractor logic

### DIFF
--- a/cmd/laravel-queues-exporter/config.go
+++ b/cmd/laravel-queues-exporter/config.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strconv"
+)
+
+// helper to get string from ENV with default
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+// help to get bool from ENV with default
+func getEnvBool(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		var boolValue bool
+		var err error
+
+		if boolValue, err = strconv.ParseBool(value); err != nil {
+			log.Printf("WARN: environment variable \"%s\"=\"%v\" can not be parsed to bool: %v", key, value, err)
+			return fallback
+		}
+		return boolValue
+	}
+	return fallback
+}
+
+// help to get int from ENV with default
+func getEnvInt(key string, fallback int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		var err error
+		var intValue int64
+		if intValue, err = strconv.ParseInt(value, 10, 8); err != nil {
+			log.Printf("WARN: environment variable \"%s\"=\"%v\" can not be parsed to integer: %v", key, value, err)
+			return fallback
+		}
+		return int(intValue)
+	}
+	return fallback
+}
+
+type globalConfig struct {
+	redisHost     string
+	redisPort     string
+	redisDB       int
+	statsdHost    string
+	statsdPort    string
+	metricsPrefix string
+	checkInterval int
+	queuesNames   string
+}
+
+var config globalConfig
+
+func getConfig() {
+	flag.StringVar(&config.redisHost, "redis-host", getEnv("REDIS_HOST", "127.0.0.1"), "Redis host where queues are stored")
+	flag.StringVar(&config.redisPort, "redis-port", getEnv("REDIS_PORT", "6379"), "Redis target port open for connections")
+	flag.IntVar(&config.redisDB, "redis-db", getEnvInt("REDIS_DB", 0), "Redis DB used by Laravel")
+	flag.StringVar(&config.statsdHost, "statsd-host", getEnv("STATSD_HOST", "127.0.0.1"), "StatsD target to where metrics must be sent")
+	flag.StringVar(&config.statsdPort, "statsd-port", getEnv("STATSD_PORT", "8125"), "StatsD target port open for connections")
+	flag.StringVar(&config.metricsPrefix, "metrics-prefix", getEnv("METRICS_PREFIX", "exporter"), "Prefix to be added to every metric")
+	flag.IntVar(&config.checkInterval, "check-interval", getEnvInt("CHECK_INTERVAL", 60), "Interval in seconds between check against queues")
+	flag.StringVar(&config.queuesNames, "queues-names", getEnv("QUEUES_NAMES", ""), "Names of the queues to be scanned separated by comma. I.e: queue1,queue2")
+
+	flag.Parse()
+}

--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/exporter/redis"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+)
+
+func main() {
+	getConfig()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGHUP, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGINT)
+
+	done := make(chan os.Signal, 1)
+	exporter := redis.NewRedisExporter(
+		config.redisHost,
+		config.redisPort,
+		config.redisDB,
+		config.checkInterval,
+		config.queuesNames,
+		nil,
+	)
+
+	exporter.Scan()
+
+	for {
+		select {
+		case signalReceived := <-signals:
+			switch signalReceived {
+			case syscall.SIGTERM:
+			case syscall.SIGINT:
+				exporter.Stop(done)
+				<-done
+				runtime.GC()
+				os.Exit(0)
+			}
+		}
+	}
+}

--- a/pkg/exporter/redis/exporter.go
+++ b/pkg/exporter/redis/exporter.go
@@ -1,0 +1,120 @@
+package redis
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	QUEUE_ROOT_NODE = "queues"
+)
+
+type RedisExporter struct {
+	targetHost    string
+	targetPort    string
+	targetDB      int
+	extractor     Extractor
+	interrupt     bool
+	checkInterval int
+	queuesNames   string
+	queueItems    []QueueItem
+}
+
+type QueueItem struct {
+	Name string
+	Jobs int64
+}
+
+type Extractor interface {
+	Connect() error
+	Close() error
+	ListQueues() ([]QueueItem, error)
+	CountJobsForQueue(queue *QueueItem) error
+}
+
+func NewRedisExporter(targetHost string,
+	targetPort string,
+	targetDB int,
+	checkInterval int,
+	queueNames string,
+	extractor Extractor) *RedisExporter {
+
+	if extractor == nil {
+		extractor = NewRedisExtractor(targetHost, targetPort, targetDB)
+	}
+
+	return &RedisExporter{targetHost: targetHost,
+		targetPort:    targetPort,
+		targetDB:      targetDB,
+		checkInterval: checkInterval,
+		queuesNames:   queueNames,
+		extractor:     extractor,
+	}
+}
+
+func (r *RedisExporter) Stop(done chan os.Signal) {
+	log.Println("Stopping exporter")
+	r.interrupt = true
+	_ = r.extractor.Close()
+	log.Println("Exporter stopped")
+	close(done)
+}
+
+func (r *RedisExporter) Scan() {
+	err := r.extractor.Connect()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ticker := time.NewTicker(time.Duration(r.checkInterval) * time.Second)
+	go func() {
+		defer ticker.Stop()
+		log.Println("Starting scanner")
+
+		for _ = range ticker.C {
+			if r.interrupt == true {
+				ticker.Stop()
+				break
+			}
+
+			queues, err := r.SelectQueuesToScan()
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for _, queue := range queues {
+				err = r.extractor.CountJobsForQueue(&queue)
+				if err != nil {
+					log.Println(fmt.Sprintf("error getting metrics for %s: %v", queue.Name, err))
+				}
+
+				log.Println(strings.Replace(queue.Name, fmt.Sprintf("%s:", QUEUE_ROOT_NODE), "", 1), queue.Jobs)
+			}
+		}
+	}()
+}
+
+func (r *RedisExporter) SelectQueuesToScan() (queueItems []QueueItem, err error) {
+
+	if len(r.queuesNames) > 0 {
+		queueItems = parseQueueNames(r.queuesNames)
+	} else {
+		queueItems, err = r.extractor.ListQueues()
+	}
+
+	return queueItems, err
+}
+
+func parseQueueNames(queueNames string) (queueItems []QueueItem) {
+
+	names := strings.Split(queueNames, ",")
+	for _, n := range names {
+		queueItems = append(queueItems, QueueItem{Name: n})
+	}
+
+	return queueItems
+}

--- a/pkg/exporter/redis/exporter_test.go
+++ b/pkg/exporter/redis/exporter_test.go
@@ -1,0 +1,66 @@
+package redis
+
+import (
+	"strings"
+	"testing"
+)
+
+type FakeRedisExtractor struct {
+	Queues []string
+}
+
+func (f *FakeRedisExtractor) Connect() error {
+	return nil
+}
+
+func (f *FakeRedisExtractor) Close() error {
+	return nil
+}
+
+func (f *FakeRedisExtractor) ListQueues() (queueItems []QueueItem, err error) {
+	for _, q := range f.Queues {
+		queueItems = append(queueItems, QueueItem{
+			Name: q,
+		})
+	}
+
+	return queueItems, err
+}
+
+func (f *FakeRedisExtractor) CountJobsForQueue(queue *QueueItem) error {
+	panic("implement me")
+}
+
+func TestShouldSelectAllQueuesToScan(t *testing.T) {
+	extractor := &FakeRedisExtractor{
+		Queues: []string{"queue1", "queue2", "queue3"},
+	}
+
+	exporter := NewRedisExporter("none", "none", 0, 5, "", extractor)
+
+	selected, _ := exporter.SelectQueuesToScan()
+
+	for i := range extractor.Queues {
+		if selected[i].Name != extractor.Queues[i] {
+			t.Errorf("expected %s, actual: %s", selected[i].Name, extractor.Queues[i])
+		}
+	}
+}
+
+func TestShouldSelectFilteredQueuesToScan(t *testing.T) {
+	extractor := &FakeRedisExtractor{
+		Queues: []string{"queue1", "queue2", "queue3"},
+	}
+
+	filtered := []string{"queue4", "queue5", "queue6"}
+
+	exporter := NewRedisExporter("none", "none", 0, 5, strings.Join(filtered, ","), extractor)
+
+	selected, _ := exporter.SelectQueuesToScan()
+
+	for i := range extractor.Queues {
+		if selected[i].Name != filtered[i] {
+			t.Errorf("expected %s, actual: %s", selected[i].Name, filtered[i])
+		}
+	}
+}

--- a/pkg/exporter/redis/extractor.go
+++ b/pkg/exporter/redis/extractor.go
@@ -1,0 +1,117 @@
+package redis
+
+import (
+	"fmt"
+	"github.com/gomodule/redigo/redis"
+	"log"
+	"strings"
+	"time"
+)
+
+type RedisExtractor struct {
+	targetHost string
+	targetPort string
+	targetDB   int
+	conn       redis.Conn
+}
+
+func NewRedisExtractor(targetHost string, targetPort string, targetDB int) *RedisExtractor {
+	return &RedisExtractor{targetHost: targetHost, targetPort: targetPort, targetDB: targetDB}
+}
+
+func (r *RedisExtractor) Close() (err error) {
+	log.Println("Closing extractor connection")
+	if r.conn != nil {
+		err = r.conn.Close()
+	}
+
+	return err
+}
+
+func (r *RedisExtractor) Connect() (err error) {
+	if r.conn != nil && r.conn.Err() == nil {
+		return nil
+	}
+
+	conn, err := redis.Dial("tcp", fmt.Sprintf("%s:%s", r.targetHost, r.targetPort), redis.DialDatabase(r.targetDB), redis.DialConnectTimeout(15*time.Second))
+	if err != nil {
+		return err
+	}
+
+	r.conn = conn
+	return nil
+}
+
+func (re *RedisExtractor) ListQueues() (queueItems []QueueItem, err error) {
+	err = re.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := re.conn.Do("KEYS", fmt.Sprintf("%s:*", QUEUE_ROOT_NODE))
+
+	if err != nil {
+		return nil, err
+	}
+
+	parsedList, err := redis.Strings(list, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, q := range parsedList {
+		queueItems = append(queueItems, QueueItem{
+			Name: q,
+		})
+	}
+	return queueItems, err
+}
+
+func checkQueueName(name string) string {
+	parts := strings.Split(name, ":")
+
+	if len(parts) == 1 {
+		name = fmt.Sprintf("%s:%s", QUEUE_ROOT_NODE, name)
+	} else if len(parts) > 1 {
+		if parts[0] != QUEUE_ROOT_NODE {
+			name = fmt.Sprintf("%s:%s", QUEUE_ROOT_NODE, name)
+		}
+	}
+
+	return name
+}
+
+func (re *RedisExtractor) CountJobsForQueue(queue *QueueItem) (err error) {
+	err = re.Connect()
+	if err != nil {
+		return err
+	}
+
+	name := checkQueueName(queue.Name)
+	queueType, err := redis.String(re.conn.Do("type", name))
+
+	if err != nil {
+		return err
+	}
+
+	var jobsCount int64
+	var redisCmd string
+
+	switch queueType {
+	case "zset":
+		redisCmd = "zcard"
+	case "list":
+		redisCmd = "llen"
+	case "none":
+		redisCmd = "llen"
+	}
+
+	jobsCount, err = redis.Int64(re.conn.Do(redisCmd, name))
+	if err != nil {
+		return err
+	}
+
+	queue.Jobs = jobsCount
+	return err
+}


### PR DESCRIPTION
This PR adds the initial work related to queues extractor and exporter.

Details about each component can be found below:

- Extractor: Responsible for connecting to a Redis server where Laravel is pushing jobs. This component holds the connections duties, queue names list and filter, and the counting of jobs associated with extracted queues.

- Exporter: Uses the extractor component in order to get access to metrics from queues. At this stage, its responsibilities are: parse initial configuration and arguments, use the extractor for defining which queues will be scanned, scan queues on a intervals bases and output the results.

In future, the exporter will have a forwarder service that will send metrics to StatsD.