### PR TITLE
Add config based structure for exporter, connector and extractor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   name = "github.com/gomodule/redigo"
   packages = [
     "internal",
@@ -10,9 +16,24 @@
   revision = "9c11da706d9b7902c6da69c592f75637793fe121"
   version = "v2.0.0"
 
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a44d2702ff44e2a72e240620f1d6633bdb6466aa1a68a494ed3833bd675e5b66"
+  inputs-digest = "2fd6b3a77dfda206c5ca7701151042568a9c6b817ead91f0f517f73c46ea42f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/exporter/redis"
+	"log"
 	"os"
 	"os/signal"
 	"runtime"
@@ -13,17 +14,48 @@ func main() {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGHUP, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGINT)
-
 	done := make(chan os.Signal, 1)
-	exporter := redis.NewRedisExporter(
-		config.redisHost,
-		config.redisPort,
-		config.redisDB,
-		config.checkInterval,
-		config.queuesNames,
-		nil,
-		nil,
-	)
+
+	connectionConfig := redis.ConnectionConfig{
+		Host: config.redisHost,
+		Port: config.redisPort,
+		DB:   config.redisDB,
+	}
+
+	connectorConfig := redis.ConnectorConfig{
+		ConnConfig: connectionConfig,
+	}
+	connector, err := redis.NewRedisConnector(connectorConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dispatcher, err := redis.NewRedisCommandDispatcher(connector)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	extractorConfig := redis.ExtractorConfig{
+		ConnConfig: connectionConfig,
+		Dispatcher: dispatcher,
+	}
+	extractor, err := redis.NewRedisExtractor(extractorConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exporterConfig := redis.RedisExporterConfig{
+		ConnectionConfig: connectionConfig,
+		QueueNames:       config.queuesNames,
+		CheckInterval:    config.checkInterval,
+		Connector:        connector,
+		Extractor:        extractor,
+	}
+	exporter, err := redis.NewRedisExporter(exporterConfig)
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	exporter.Scan()
 
@@ -33,7 +65,7 @@ func main() {
 			switch signalReceived {
 			case syscall.SIGTERM:
 			case syscall.SIGINT:
-				exporter.Stop(done)
+				exporter.Stop(done) //TODO Implement ticker to avoid waiting forever
 				<-done
 				runtime.GC()
 				os.Exit(0)

--- a/pkg/exporter/redis/config.go
+++ b/pkg/exporter/redis/config.go
@@ -1,0 +1,102 @@
+package redis
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ExporterConfig struct {
+	ConnectionConfig RedisConnectionConfig
+	CheckInterval    int
+	QueueNames       string
+	Extractor        Extractor
+	Connector        Connector
+}
+
+type RedisConnectionConfig struct {
+	Host string
+	Port string
+	DB   int
+}
+
+func (c *RedisConnectionConfig) HasRequiredConnectionInfo() (bool, error) {
+	var err error
+	var missingInfo []string
+	hasRequiredInfo := true
+
+	if len(c.Host) == 0 {
+		missingInfo = append(missingInfo, "host")
+		hasRequiredInfo = false
+	}
+
+	if len(c.Port) == 0 {
+		missingInfo = append(missingInfo, "port")
+		hasRequiredInfo = false
+	}
+
+	errMessage := fmt.Sprintf("connection info has missing information for fields: %s", strings.Join(missingInfo, ", "))
+	err = errors.New(errMessage)
+
+	return hasRequiredInfo, err
+}
+
+func (c *RedisConnectionConfig) HasValidConnectionInfo() (bool, error) {
+	var err error
+	var invalidFieldMessages []string
+	hasValidInfo := true
+
+	if v, _ := c.HasValidDB(); v == false {
+		invalidFieldMessages = append(invalidFieldMessages, fmt.Sprintf("DB: %d", c.DB))
+		hasValidInfo = false
+	}
+
+	_, convErr := c.PortToInt()
+	if convErr != nil {
+		invalidFieldMessages = append(invalidFieldMessages, fmt.Sprintf("Port: %d", c.DB))
+		hasValidInfo = false
+	}
+
+	errMessage := fmt.Sprintf("connection info has invalid fields: %s", strings.Join(invalidFieldMessages, ", "))
+	err = errors.New(errMessage)
+
+	return hasValidInfo, err
+}
+
+func (c *RedisConnectionConfig) HasValidDB() (bool, error) {
+	if c.DB < 0 {
+		return false, errors.New(fmt.Sprintf("db can't be lower than zero: %d", c.DB))
+	}
+	return true, nil
+}
+
+func (c *RedisConnectionConfig) HasValidPort() (bool, error) {
+	if len(c.Port) < 0 {
+		return false, errors.New(fmt.Sprintf("port can't be blank or null: %s", c.Port))
+	}
+
+	port, err := c.PortToInt()
+
+	if err != nil {
+		return false, err
+	}
+
+	if port < 0 {
+		return false, errors.New(fmt.Sprintf("port can't be lower than zero: %s", c.Port))
+	}
+
+	return true, nil
+}
+
+func (c *RedisConnectionConfig) PortToInt() (int, error) {
+	var err error
+	var port int
+
+	port, err = strconv.Atoi(c.Port)
+	if err != nil {
+		return -1, errors.New(fmt.Sprintf("error converting port: %s", c.Port))
+	}
+
+	return port, err
+}

--- a/pkg/exporter/redis/config.go
+++ b/pkg/exporter/redis/config.go
@@ -7,21 +7,13 @@ import (
 	"strings"
 )
 
-type ExporterConfig struct {
-	ConnectionConfig RedisConnectionConfig
-	CheckInterval    int
-	QueueNames       string
-	Extractor        Extractor
-	Connector        Connector
-}
-
-type RedisConnectionConfig struct {
+type ConnectionConfig struct {
 	Host string
 	Port string
 	DB   int
 }
 
-func (c *RedisConnectionConfig) HasRequiredConnectionInfo() (bool, error) {
+func (c *ConnectionConfig) HasRequiredConnectionInfo() (bool, error) {
 	var err error
 	var missingInfo []string
 	hasRequiredInfo := true
@@ -42,7 +34,7 @@ func (c *RedisConnectionConfig) HasRequiredConnectionInfo() (bool, error) {
 	return hasRequiredInfo, err
 }
 
-func (c *RedisConnectionConfig) HasValidConnectionInfo() (bool, error) {
+func (c *ConnectionConfig) HasValidConnectionInfo() (bool, error) {
 	var err error
 	var invalidFieldMessages []string
 	hasValidInfo := true
@@ -64,14 +56,14 @@ func (c *RedisConnectionConfig) HasValidConnectionInfo() (bool, error) {
 	return hasValidInfo, err
 }
 
-func (c *RedisConnectionConfig) HasValidDB() (bool, error) {
+func (c *ConnectionConfig) HasValidDB() (bool, error) {
 	if c.DB < 0 {
 		return false, errors.New(fmt.Sprintf("db can't be lower than zero: %d", c.DB))
 	}
 	return true, nil
 }
 
-func (c *RedisConnectionConfig) HasValidPort() (bool, error) {
+func (c *ConnectionConfig) HasValidPort() (bool, error) {
 	if len(c.Port) < 0 {
 		return false, errors.New(fmt.Sprintf("port can't be blank or null: %s", c.Port))
 	}
@@ -89,7 +81,7 @@ func (c *RedisConnectionConfig) HasValidPort() (bool, error) {
 	return true, nil
 }
 
-func (c *RedisConnectionConfig) PortToInt() (int, error) {
+func (c *ConnectionConfig) PortToInt() (int, error) {
 	var err error
 	var port int
 

--- a/pkg/exporter/redis/config_test.go
+++ b/pkg/exporter/redis/config_test.go
@@ -1,0 +1,170 @@
+package redis
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_RedisConnectionConfig_ShouldCheckRequiredConnectionInfo(t *testing.T) {
+
+	testCases := []struct {
+		desc     string
+		config   RedisConnectionConfig
+		expected bool
+	}{
+		{
+			desc: "All connection info is fulfilled",
+			config: RedisConnectionConfig{
+				Host: "localhost",
+				Port: "6379",
+			},
+			expected: true,
+		}, {
+			desc: "Host info is missing",
+			config: RedisConnectionConfig{
+				Host: "",
+				Port: "6379",
+			},
+			expected: false,
+		}, {
+			desc: "Port info is missing",
+			config: RedisConnectionConfig{
+				Host: "localhost",
+				Port: "",
+			},
+			expected: false,
+		}, {
+			desc: "Host and Port info are missing",
+			config: RedisConnectionConfig{
+				Host: "",
+				Port: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hasRequiredInfo, err := tc.config.HasRequiredConnectionInfo()
+			require.Equal(t, tc.expected, hasRequiredInfo, err)
+		})
+	}
+
+}
+
+func Test_RedisConnectionConfig_ShouldCheckHasValidDB(t *testing.T) {
+
+	testCases := []struct {
+		desc     string
+		config   RedisConnectionConfig
+		expected bool
+	}{
+		{
+			desc: "DB index equals 0",
+			config: RedisConnectionConfig{
+				DB: 0,
+			},
+			expected: true,
+		},
+		{
+			desc: "DB index lower than 0",
+			config: RedisConnectionConfig{
+				DB: -1,
+			},
+			expected: false,
+		},
+		{
+			desc: "DB index greater than 0",
+			config: RedisConnectionConfig{
+				DB: 1,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hasValidDB, err := tc.config.HasValidDB()
+			require.Equal(t, tc.expected, hasValidDB, err)
+		})
+	}
+
+}
+
+func Test_RedisConnectionConfig_ShouldCheckHasValidPort(t *testing.T) {
+
+	testCases := []struct {
+		desc     string
+		config   RedisConnectionConfig
+		expected bool
+	}{
+		{
+			desc: "Port is higher than zero",
+			config: RedisConnectionConfig{
+				Port: "6379",
+			},
+			expected: true,
+		},
+		{
+			desc: "Port is equals zero",
+			config: RedisConnectionConfig{
+				Port: "0",
+			},
+			expected: true,
+		},
+		{
+			desc: "Port is lower than zero",
+			config: RedisConnectionConfig{
+				Port: "-6379",
+			},
+			expected: false,
+		},
+		{
+			desc: "Port is blank",
+			config: RedisConnectionConfig{
+				Port: "",
+			},
+			expected: false,
+		},
+		{
+			desc:     "Port is null",
+			config:   RedisConnectionConfig{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hasValidPort, err := tc.config.HasValidPort()
+			require.Equal(t, tc.expected, hasValidPort, err)
+		})
+	}
+
+}
+
+func Test_RedisConnectionConfig_ShouldCheckHasValidConnectionInfo(t *testing.T) {
+
+	testCases := []struct {
+		desc     string
+		config   RedisConnectionConfig
+		expected bool
+	}{
+		{
+			desc: "All configs set properly",
+			config: RedisConnectionConfig{
+				Host: "localhost",
+				Port: "6379",
+				DB:   0,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hasValidInfo, err := tc.config.HasValidConnectionInfo()
+			require.Equal(t, tc.expected, hasValidInfo, err)
+		})
+	}
+
+}

--- a/pkg/exporter/redis/config_test.go
+++ b/pkg/exporter/redis/config_test.go
@@ -9,33 +9,33 @@ func Test_RedisConnectionConfig_ShouldCheckRequiredConnectionInfo(t *testing.T) 
 
 	testCases := []struct {
 		desc     string
-		config   RedisConnectionConfig
+		config   ConnectionConfig
 		expected bool
 	}{
 		{
 			desc: "All connection info is fulfilled",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Host: "localhost",
 				Port: "6379",
 			},
 			expected: true,
 		}, {
 			desc: "Host info is missing",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Host: "",
 				Port: "6379",
 			},
 			expected: false,
 		}, {
 			desc: "Port info is missing",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Host: "localhost",
 				Port: "",
 			},
 			expected: false,
 		}, {
 			desc: "Host and Port info are missing",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Host: "",
 				Port: "",
 			},
@@ -56,26 +56,26 @@ func Test_RedisConnectionConfig_ShouldCheckHasValidDB(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		config   RedisConnectionConfig
+		config   ConnectionConfig
 		expected bool
 	}{
 		{
 			desc: "DB index equals 0",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				DB: 0,
 			},
 			expected: true,
 		},
 		{
 			desc: "DB index lower than 0",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				DB: -1,
 			},
 			expected: false,
 		},
 		{
 			desc: "DB index greater than 0",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				DB: 1,
 			},
 			expected: true,
@@ -95,40 +95,40 @@ func Test_RedisConnectionConfig_ShouldCheckHasValidPort(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		config   RedisConnectionConfig
+		config   ConnectionConfig
 		expected bool
 	}{
 		{
 			desc: "Port is higher than zero",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Port: "6379",
 			},
 			expected: true,
 		},
 		{
 			desc: "Port is equals zero",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Port: "0",
 			},
 			expected: true,
 		},
 		{
 			desc: "Port is lower than zero",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Port: "-6379",
 			},
 			expected: false,
 		},
 		{
 			desc: "Port is blank",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Port: "",
 			},
 			expected: false,
 		},
 		{
 			desc:     "Port is null",
-			config:   RedisConnectionConfig{},
+			config:   ConnectionConfig{},
 			expected: false,
 		},
 	}
@@ -146,12 +146,12 @@ func Test_RedisConnectionConfig_ShouldCheckHasValidConnectionInfo(t *testing.T) 
 
 	testCases := []struct {
 		desc     string
-		config   RedisConnectionConfig
+		config   ConnectionConfig
 		expected bool
 	}{
 		{
 			desc: "All configs set properly",
-			config: RedisConnectionConfig{
+			config: ConnectionConfig{
 				Host: "localhost",
 				Port: "6379",
 				DB:   0,

--- a/pkg/exporter/redis/connector.go
+++ b/pkg/exporter/redis/connector.go
@@ -8,14 +8,16 @@ import (
 )
 
 type RedisConnector struct {
-	targetHost string
-	targetPort string
-	targetDB   int
-	conn       redis.Conn
+	Config ConnectorConfig
+	conn   redis.Conn
 }
 
-func NewRedisConnector(targetHost string, targetPort string, targetDB int) *RedisConnector {
-	return &RedisConnector{targetHost: targetHost, targetPort: targetPort, targetDB: targetDB}
+type ConnectorConfig struct {
+	ConnConfig ConnectionConfig
+}
+
+func NewRedisConnector(config ConnectorConfig) (*RedisConnector, error) {
+	return &RedisConnector{Config: config}, nil
 }
 
 func (c *RedisConnector) Connect() (err error) {
@@ -23,7 +25,7 @@ func (c *RedisConnector) Connect() (err error) {
 		return nil
 	}
 
-	conn, err := redis.Dial("tcp", fmt.Sprintf("%s:%s", c.targetHost, c.targetPort), redis.DialDatabase(c.targetDB), redis.DialConnectTimeout(15*time.Second))
+	conn, err := redis.Dial("tcp", fmt.Sprintf("%s:%s", c.Config.ConnConfig.Host, c.Config.ConnConfig.Port), redis.DialDatabase(c.Config.ConnConfig.DB), redis.DialConnectTimeout(15*time.Second))
 	if err != nil {
 		return err
 	}

--- a/pkg/exporter/redis/dispatcher.go
+++ b/pkg/exporter/redis/dispatcher.go
@@ -1,22 +1,19 @@
 package redis
 
+import "errors"
+
 type RedisCommandDispatcher struct {
 	connector Connector
 }
 
-type Connector interface {
-	Connect() (err error)
-	Close() (err error)
-	Do(command string, args ...interface{}) (results interface{}, err error)
-}
-
-func NewRedisCommandDispatcher(connector Connector) *RedisCommandDispatcher {
-	if connector != nil {
-		return &RedisCommandDispatcher{connector: connector}
+func NewRedisCommandDispatcher(connector Connector) (*RedisCommandDispatcher, error) {
+	if connector == nil {
+		return nil, errors.New("connector can't be nil")
 	}
-	return nil
+
+	return &RedisCommandDispatcher{connector: connector}, nil
 }
 
 func (d *RedisCommandDispatcher) Do(command string, args ...interface{}) (results interface{}, err error) {
-	return d.connector.Do(command, args)
+	return d.connector.Do(command, args...)
 }


### PR DESCRIPTION
This PRs adds the ability of having all the required configs to get the exporter running.

There are some shared structs that holds connections configs.

That makes the code much cleaner and understandable.