### PR TITLE
Extract set queue type process to its own method

### DIFF
--- a/pkg/exporter/redis/exporter.go
+++ b/pkg/exporter/redis/exporter.go
@@ -26,6 +26,7 @@ type ExporterConfig struct {
 	Connector        Connector
 }
 
+//TODO extract to a separated file
 type QueueItem struct {
 	Name string
 	Type string
@@ -35,7 +36,7 @@ type QueueItem struct {
 type Extractor interface {
 	ListAllQueuesFromDB() ([]*QueueItem, error)
 	CountJobsForQueue(queue *QueueItem) error
-	SetQueuesType(queues []*QueueItem)
+	SetQueueTypeForQueues(queues []*QueueItem)
 }
 
 type Connector interface {
@@ -127,14 +128,6 @@ func (xp *Exporter) SelectQueuesToScan() ([]*QueueItem, error) {
 	return queueItems, err
 }
 
-func (xp *Exporter) SetQueuesType(queues []*QueueItem) {
-	xp.Extractor().SetQueuesType(queues)
-}
-
-func (xp *Exporter) Extractor() Extractor {
-	return xp.Config.Extractor
-}
-
 func parsedQueuesNames(queueNames string) []*QueueItem {
 	queueItems := []*QueueItem{}
 	names := strings.Split(queueNames, ",")
@@ -143,6 +136,14 @@ func parsedQueuesNames(queueNames string) []*QueueItem {
 	}
 
 	return queueItems
+}
+
+func (xp *Exporter) SetQueuesType(queues []*QueueItem) {
+	xp.Extractor().SetQueueTypeForQueues(queues)
+}
+
+func (xp *Exporter) Extractor() Extractor {
+	return xp.Config.Extractor
 }
 
 func (q *QueueItem) LaravelQueueName() string {

--- a/pkg/exporter/redis/exporter_test.go
+++ b/pkg/exporter/redis/exporter_test.go
@@ -20,9 +20,9 @@ func (f *FakeRedisExtractor) Close() error {
 	return nil
 }
 
-func (f *FakeRedisExtractor) ListAllQueuesFromDB() (queueItems []QueueItem, err error) {
+func (f *FakeRedisExtractor) ListAllQueuesFromDB() (queueItems []*QueueItem, err error) {
 	for _, q := range f.QueuesOnDB {
-		queueItems = append(queueItems, QueueItem{
+		queueItems = append(queueItems, &QueueItem{
 			Name: q,
 		})
 	}
@@ -31,6 +31,10 @@ func (f *FakeRedisExtractor) ListAllQueuesFromDB() (queueItems []QueueItem, err 
 }
 
 func (f *FakeRedisExtractor) CountJobsForQueue(queue *QueueItem) error {
+	panic("implement me")
+}
+
+func (f *FakeRedisExtractor) SetQueuesType(queues []*QueueItem) {
 	panic("implement me")
 }
 
@@ -61,7 +65,7 @@ func Test_Exporter_ShouldReturnAllQueuesFromDB(t *testing.T) {
 
 	exporter, _ := NewRedisExporter(config)
 
-	actual := func(queueItems []QueueItem) string {
+	actual := func(queueItems []*QueueItem) string {
 		var names []string
 		for _, q := range queueItems {
 			names = append(names, q.Name)
@@ -69,7 +73,7 @@ func Test_Exporter_ShouldReturnAllQueuesFromDB(t *testing.T) {
 		return strings.Join(names, ",")
 	}
 
-	dbMatchesSelected := func(fromDB []string, selected []QueueItem) (bool, error) {
+	dbMatchesSelected := func(fromDB []string, selected []*QueueItem) (bool, error) {
 		allMatch := true
 		var err error
 		for _, queue := range fromDB {
@@ -94,7 +98,7 @@ func Test_Exporter_ShouldReturnAllQueuesFromDB(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		remoteQueues        []string
-		validateQueuesMatch func(fromDB []string, selected []QueueItem) (bool, error)
+		validateQueuesMatch func(fromDB []string, selected []*QueueItem) (bool, error)
 		expected            bool
 	}{
 		{
@@ -125,7 +129,7 @@ func Test_Exporter_ShouldSelectFilteredQueuesFromDB(t *testing.T) {
 
 	exporter, _ := NewRedisExporter(config)
 
-	actual := func(queueItems []QueueItem) string {
+	actual := func(queueItems []*QueueItem) string {
 		var names []string
 		for _, q := range queueItems {
 			names = append(names, q.Name)
@@ -133,7 +137,7 @@ func Test_Exporter_ShouldSelectFilteredQueuesFromDB(t *testing.T) {
 		return strings.Join(names, ",")
 	}
 
-	configMatchesSelected := func(fromConfig string, selected []QueueItem) (bool, error) {
+	configMatchesSelected := func(fromConfig string, selected []*QueueItem) (bool, error) {
 		allMatch := true
 		var err error
 		for _, queue := range strings.Split(fromConfig, ",") {
@@ -159,7 +163,7 @@ func Test_Exporter_ShouldSelectFilteredQueuesFromDB(t *testing.T) {
 		desc                string
 		remoteQueues        []string
 		queuesFromConfig    string
-		validateQueuesMatch func(fromConfig string, actual []QueueItem) (bool, error)
+		validateQueuesMatch func(fromConfig string, actual []*QueueItem) (bool, error)
 		expected            bool
 	}{
 		{

--- a/pkg/exporter/redis/exporter_test.go
+++ b/pkg/exporter/redis/exporter_test.go
@@ -34,7 +34,7 @@ func (f *FakeRedisExtractor) CountJobsForQueue(queue *QueueItem) error {
 	panic("implement me")
 }
 
-func (f *FakeRedisExtractor) SetQueuesType(queues []*QueueItem) {
+func (f *FakeRedisExtractor) SetQueueTypeForQueues(queues []*QueueItem) {
 	panic("implement me")
 }
 

--- a/pkg/exporter/redis/extractor.go
+++ b/pkg/exporter/redis/extractor.go
@@ -58,10 +58,10 @@ func (xt *RedisExtractor) CountJobsForQueue(queue *QueueItem) error {
 	queueName := queue.LaravelQueueName()
 
 	var jobsCount int64
-	redisCmd := xt.CountJobCmdNameByQueueType(queue.Type)
+	cmdName := xt.CountJobsCmdNameByQueueType(queue.Type)
 
 	//TODO Implement a parser instead of using package directly
-	jobsCount, err := redis.Int64(xt.Dispatcher().Do(redisCmd, queueName))
+	jobsCount, err := redis.Int64(xt.Dispatcher().Do(cmdName, queueName))
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (xt *RedisExtractor) CountJobsForQueue(queue *QueueItem) error {
 	return err
 }
 
-func (xt *RedisExtractor) SetQueuesType(queues []*QueueItem) {
+func (xt *RedisExtractor) SetQueueTypeForQueues(queues []*QueueItem) {
 	for i, queue := range queues {
 		queueType, err := redis.String(xt.Dispatcher().Do("type", queue.Name))
 
@@ -82,7 +82,7 @@ func (xt *RedisExtractor) SetQueuesType(queues []*QueueItem) {
 	}
 }
 
-func (xt *RedisExtractor) CountJobCmdNameByQueueType(queueType string) string {
+func (xt *RedisExtractor) CountJobsCmdNameByQueueType(queueType string) string {
 	var cmd string
 
 	switch queueType {

--- a/pkg/exporter/redis/extractor.go
+++ b/pkg/exporter/redis/extractor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/gomodule/redigo/redis"
+	"log"
 )
 
 type RedisExtractor struct {
@@ -72,9 +73,12 @@ func (xt *RedisExtractor) CountJobsForQueue(queue *QueueItem) error {
 func (xt *RedisExtractor) SetQueuesType(queues []*QueueItem) {
 	for i, queue := range queues {
 		queueType, err := redis.String(xt.Dispatcher().Do("type", queue.Name))
-		if err == nil {
-			queues[i].Type = queueType
+
+		if err != nil {
+			log.Printf("error: type could not defined for queue %s", queue.Name)
 		}
+
+		queues[i].Type = queueType
 	}
 }
 

--- a/pkg/exporter/redis/extractor_test.go
+++ b/pkg/exporter/redis/extractor_test.go
@@ -87,7 +87,7 @@ func Test_RedisExtractor_ShouldListAllQueuesFromDB(t *testing.T) {
 	assert.Equal(t, queuesMatch(queuesFromDB, queueItems), true)
 }
 
-func Test_RedisExtractor_ShouldReturnCommandByQueueType(t *testing.T) {
+func Test_RedisExtractor_ShouldReturnCountJobCommandNameByQueueType(t *testing.T) {
 	dispatcher := new(FakeDispatcher)
 
 	config := ExtractorConfig{
@@ -121,14 +121,14 @@ func Test_RedisExtractor_ShouldReturnCommandByQueueType(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			cmd := extractor.CountJobCmdNameByQueueType(tc.queueType)
+			cmd := extractor.CountJobsCmdNameByQueueType(tc.queueType)
 			assert.Equal(t, tc.expected, cmd)
 		})
 	}
 
 }
 
-func Test_RedisExtractor_GivenQueuesShouldSetQueueType(t *testing.T) {
+func Test_RedisExtractor_GivenQueueItemsShouldSetQueueType(t *testing.T) {
 	dispatcher := new(FakeDispatcher)
 	cmd := "type"
 
@@ -183,7 +183,7 @@ func Test_RedisExtractor_GivenQueuesShouldSetQueueType(t *testing.T) {
 				dispatcher.On("Do", cmd, args).Return(queueType).Once()
 			}
 
-			extractor.SetQueuesType(tc.queues)
+			extractor.SetQueueTypeForQueues(tc.queues)
 			for _, q := range tc.queues {
 				assert.Equal(t, q.Type, tc.expected[q.Name])
 			}

--- a/pkg/exporter/redis/extractor_test.go
+++ b/pkg/exporter/redis/extractor_test.go
@@ -145,7 +145,7 @@ func Test_RedisExtractor_GivenQueuesShouldSetQueueType(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			desc: "Set queue type for queues",
+			desc: "Set queue type for queues when they are present on DB",
 			queues: []*QueueItem{
 				{Name: "queue1"},
 				{Name: "queue2"},
@@ -157,6 +157,20 @@ func Test_RedisExtractor_GivenQueuesShouldSetQueueType(t *testing.T) {
 				"queue3": "none",
 			},
 		},
+		{
+			desc: "Do not set queue type for queues not present on DB",
+			queues: []*QueueItem{
+				{Name: "queue4"},
+				{Name: "queue5"},
+				{Name: "queue6"},
+				{Name: "queue7"},
+			},
+			expected: map[string]string{
+				"queue4": "none",
+				"queue5": "none",
+				"queue6": "none",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -165,7 +179,8 @@ func Test_RedisExtractor_GivenQueuesShouldSetQueueType(t *testing.T) {
 				args := []interface{}{
 					q.Name,
 				}
-				dispatcher.On("Do", cmd, args).Return(tc.expected[q.Name])
+				queueType := tc.expected[q.Name]
+				dispatcher.On("Do", cmd, args).Return(queueType).Once()
 			}
 
 			extractor.SetQueuesType(tc.queues)


### PR DESCRIPTION
This refactoring extracts the process of setting the queue type to its own function.

The goal here is to make the code base cleaner.