### PR TITLE
Remove RedisExporter connector and extractor from RedisExporterConfig

### DIFF
--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/exporter/redis"
 	"log"
 	"os"
@@ -54,10 +55,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	exporter.Scan()
+	collected := make(chan string)
+	exporter.Run(collected)
 
 	for {
 		select {
+		case forwardChan := <-collected:
+			fmt.Println(forwardChan)
 		case signalReceived := <-signals:
 			switch signalReceived {
 			case syscall.SIGTERM:

--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -47,10 +47,8 @@ func main() {
 		ConnectionConfig: connectionConfig,
 		QueueNames:       config.queuesNames,
 		ScanInterval:     config.scanInterval,
-		Connector:        connector,
-		Extractor:        extractor,
 	}
-	exporter, err := redis.NewRedisExporter(exporterConfig)
+	exporter, err := redis.NewRedisExporter(exporterConfig, connector, extractor)
 
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/exporter/redis/exporter.go
+++ b/pkg/exporter/redis/exporter.go
@@ -68,7 +68,6 @@ func (xp *Exporter) CloseConnector() error {
 }
 
 func (xp *Exporter) Run(collected chan string) {
-func (xp *Exporter) Scan() {
 	ticker := time.NewTicker(time.Duration(xp.Config.ScanInterval) * time.Second)
 	go func() {
 		defer ticker.Stop()
@@ -101,7 +100,8 @@ func (xp *Exporter) Scan() {
 				}
 
 				//TODO Implement RedisQueueMetricsFormatter to output metrics
-				log.Println(strings.Replace(q.Name(), fmt.Sprintf("%s:", QUEUE_ROOT_NODE), "", 1), q.GetCurrentJobsCount())
+				metric := fmt.Sprintf("%s %d", q.Name(), q.GetCurrentJobsCount())
+				collected <- metric
 			}
 		}
 	}()

--- a/pkg/exporter/redis/exporter.go
+++ b/pkg/exporter/redis/exporter.go
@@ -12,16 +12,16 @@ import (
 
 type Exporter struct {
 	Config        ExporterConfig
-	interruptScan bool
+	Extractor     Extractor
+	Connector     Connector
 	Queues        []*RedisQueue
+	interruptScan bool
 }
 
 type ExporterConfig struct {
 	ConnectionConfig ConnectionConfig
 	ScanInterval     int
 	QueueNames       string
-	Extractor        Extractor
-	Connector        Connector
 }
 
 type Extractor interface {
@@ -36,17 +36,19 @@ type Connector interface {
 	Do(command string, args ...interface{}) (results interface{}, err error)
 }
 
-func NewRedisExporter(config ExporterConfig) (*Exporter, error) {
-	if config.Connector == nil {
+func NewRedisExporter(config ExporterConfig, connector Connector, extractor Extractor) (*Exporter, error) {
+	if connector == nil {
 		return nil, errors.New("connector can't be nil")
 	}
 
-	if config.Extractor == nil {
+	if extractor == nil {
 		return nil, errors.New("extractor can't be nil")
 	}
 
 	return &Exporter{
-		Config: config,
+		Config:    config,
+		Connector: connector,
+		Extractor: extractor,
 	}, nil
 }
 
@@ -62,13 +64,10 @@ func (xp *Exporter) Stop(done chan os.Signal) {
 }
 
 func (xp *Exporter) CloseConnector() error {
-	return xp.Connector().Close()
+	return xp.Connector.Close()
 }
 
-func (xp *Exporter) Connector() Connector {
-	return xp.Config.Connector
-}
-
+func (xp *Exporter) Run(collected chan string) {
 func (xp *Exporter) Scan() {
 	ticker := time.NewTicker(time.Duration(xp.Config.ScanInterval) * time.Second)
 	go func() {
@@ -109,7 +108,7 @@ func (xp *Exporter) Scan() {
 }
 
 func (xp *Exporter) CountJobsForQueues(queues []*RedisQueue) error {
-	return xp.Extractor().CountJobsForQueues(queues)
+	return xp.Extractor.CountJobsForQueues(queues)
 }
 
 func (xp *Exporter) SelectQueuesToScan() ([]*RedisQueue, error) {
@@ -119,7 +118,7 @@ func (xp *Exporter) SelectQueuesToScan() ([]*RedisQueue, error) {
 	if len(xp.Config.QueueNames) > 0 {
 		queueItems = parsedQueuesNames(xp.Config.QueueNames)
 	} else {
-		queueItems, err = xp.Extractor().ListAllQueuesFromDB()
+		queueItems, err = xp.Extractor.ListAllQueuesFromDB()
 	}
 
 	return queueItems, err
@@ -136,9 +135,5 @@ func parsedQueuesNames(queueNames string) []*RedisQueue {
 }
 
 func (xp *Exporter) SetQueuesType(queues []*RedisQueue) {
-	xp.Extractor().SetQueueTypeForQueues(queues)
-}
-
-func (xp *Exporter) Extractor() Extractor {
-	return xp.Config.Extractor
+	xp.Extractor.SetQueueTypeForQueues(queues)
 }

--- a/pkg/exporter/redis/exporter_test.go
+++ b/pkg/exporter/redis/exporter_test.go
@@ -61,12 +61,9 @@ func Test_Exporter_ShouldReturnAllQueuesFromDB(t *testing.T) {
 		QueuesOnDB: []string{"queue1", "queue2", "queue3"},
 	}
 	connector := &FakeRedisConnector{}
-	config := ExporterConfig{
-		Extractor: extractor,
-		Connector: connector,
-	}
+	config := ExporterConfig{}
 
-	exporter, _ := NewRedisExporter(config)
+	exporter, _ := NewRedisExporter(config, connector, extractor)
 
 	actual := func(queueItems []*RedisQueue) string {
 		var names []string
@@ -125,12 +122,9 @@ func Test_Exporter_ShouldReturnAllQueuesFromDB(t *testing.T) {
 func Test_Exporter_ShouldSelectFilteredQueuesFromDB(t *testing.T) {
 	extractor := &FakeRedisExtractor{}
 	connector := &FakeRedisConnector{}
-	config := ExporterConfig{
-		Extractor: extractor,
-		Connector: connector,
-	}
+	config := ExporterConfig{}
 
-	exporter, _ := NewRedisExporter(config)
+	exporter, _ := NewRedisExporter(config, connector, extractor)
 
 	actual := func(queueItems []*RedisQueue) string {
 		var names []string
@@ -207,7 +201,7 @@ func Test_Exporter_ShouldSelectFilteredQueuesFromDB(t *testing.T) {
 
 func Test_Exporter_ShouldReturnLaravelQueueNameForGivenQueueName(t *testing.T) {
 	nameWithRootNode := func(name string) string {
-		return fmt.Sprintf("%s:%s", QUEUE_ROOT_NODE, name)
+		return fmt.Sprintf("%s:%s", LARAVEL_QUEUE_ROOT_NODE, name)
 	}
 
 	testCases := []struct {
@@ -267,7 +261,7 @@ func Test_Exporter_ShouldReturnLaravelQueueNameForGivenQueueName(t *testing.T) {
 					Name: nameWithRootNode(":"),
 				},
 			},
-			expected: QUEUE_ROOT_NODE,
+			expected: LARAVEL_QUEUE_ROOT_NODE,
 		},
 		{
 			desc: "RedisQueue name has not parent node",
@@ -282,7 +276,7 @@ func Test_Exporter_ShouldReturnLaravelQueueNameForGivenQueueName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			name := tc.queueItem.ToLaravel()
+			name := tc.queueItem.FullName()
 			require.Equal(t, tc.expected, name)
 		})
 	}

--- a/pkg/exporter/redis/extractor.go
+++ b/pkg/exporter/redis/extractor.go
@@ -31,7 +31,7 @@ func (xt *RedisExtractor) ListAllQueuesFromDB() ([]*RedisQueue, error) {
 	var err error
 	queueItems := []*RedisQueue{}
 
-	list, err := xt.Dispatcher().Do("keys", fmt.Sprintf("%s:*", QUEUE_ROOT_NODE))
+	list, err := xt.Dispatcher().Do("keys", fmt.Sprintf("%s:*", LARAVEL_QUEUE_ROOT_NODE))
 
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (xt *RedisExtractor) CountJobsForQueues(queues []*RedisQueue) error {
 	var err error
 
 	for _, q := range queues {
-		queueName := q.ToLaravel()
+		queueName := q.FullName()
 
 		var jobsCount int64
 		cmdName := xt.CountJobsCmdNameByQueueType(q.GetQueueType())

--- a/pkg/exporter/redis/extractor_test.go
+++ b/pkg/exporter/redis/extractor_test.go
@@ -45,7 +45,7 @@ func Test_RedisExtractor_ShouldListAllQueuesFromDB(t *testing.T) {
 
 	cmd := "keys"
 	args := []interface{}{
-		fmt.Sprintf("%s:*", QUEUE_ROOT_NODE),
+		fmt.Sprintf("%s:*", LARAVEL_QUEUE_ROOT_NODE),
 	}
 
 	queuesFromDB := []interface{}{

--- a/pkg/exporter/redis/queue.go
+++ b/pkg/exporter/redis/queue.go
@@ -1,12 +1,13 @@
 package redis
 
 import (
+	"fmt"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/queue"
 	"strings"
 )
 
 const (
-	QUEUE_ROOT_NODE = "queues"
+	LARAVEL_QUEUE_ROOT_NODE = "queues"
 )
 
 type RedisQueue struct {
@@ -15,7 +16,7 @@ type RedisQueue struct {
 }
 
 func (q *RedisQueue) Name() string {
-	return q.queueItem.Name
+	return strings.Replace(q.queueItem.Name, fmt.Sprintf("%s:", LARAVEL_QUEUE_ROOT_NODE), "", 1)
 }
 
 func (q *RedisQueue) GetQueueType() string {
@@ -34,7 +35,7 @@ func (q *RedisQueue) SetCurrentJobsCount(count int64) {
 	q.queueItem.Jobs = count
 }
 
-func (q *RedisQueue) ToLaravel() string {
+func (q *RedisQueue) FullName() string {
 	var laravelName string
 
 	if q.queueItem == nil || q.queueItem.HasQueueName() == false {
@@ -48,11 +49,11 @@ func (q *RedisQueue) ToLaravel() string {
 		return laravelName
 	case partsCount >= 1:
 		tmpParts := []string{
-			QUEUE_ROOT_NODE,
+			LARAVEL_QUEUE_ROOT_NODE,
 		}
 
 		for _, p := range parts {
-			if len(p) > 0 && p != QUEUE_ROOT_NODE {
+			if len(p) > 0 && p != LARAVEL_QUEUE_ROOT_NODE {
 				tmpParts = append(tmpParts, p)
 			}
 		}


### PR DESCRIPTION
Move dependencies out from config. The config should be restricted to application initial configs.