### PR TITLE
Fix queue name used when setting queue type

### DIFF
--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -15,6 +15,7 @@ type Forwarder interface {
 	Forward(metrics []metric.Metric)
 }
 
+//TODO Extract exporter and dependencies initialisation from main()
 func main() {
 	getConfig()
 

--- a/pkg/exporter/redis/extractor.go
+++ b/pkg/exporter/redis/extractor.go
@@ -80,10 +80,10 @@ func (xt *RedisExtractor) CountJobsForQueues(queues []*RedisQueue) error {
 
 func (xt *RedisExtractor) SetQueueTypeForQueues(queues []*RedisQueue) {
 	for i, q := range queues {
-		queueType, err := redis.String(xt.Dispatcher().Do("type", q.Name()))
+		queueType, err := redis.String(xt.Dispatcher().Do("type", q.FullName()))
 
 		if err != nil {
-			log.Printf("error: type could not be defined for queue %s", q.Name())
+			log.Printf("error: type could not be defined for queue %s", q.FullName())
 		}
 
 		queues[i].SetQueueType(queueType)

--- a/pkg/exporter/redis/queue.go
+++ b/pkg/exporter/redis/queue.go
@@ -19,22 +19,6 @@ func (q *RedisQueue) Name() string {
 	return strings.Replace(q.queueItem.Name, fmt.Sprintf("%s:", LARAVEL_QUEUE_ROOT_NODE), "", 1)
 }
 
-func (q *RedisQueue) GetQueueType() string {
-	return q.queueType
-}
-
-func (q *RedisQueue) SetQueueType(queueType string) {
-	q.queueType = queueType
-}
-
-func (q *RedisQueue) GetCurrentJobsCount() int64 {
-	return q.queueItem.Jobs
-}
-
-func (q *RedisQueue) SetCurrentJobsCount(count int64) {
-	q.queueItem.Jobs = count
-}
-
 func (q *RedisQueue) FullName() string {
 	var laravelName string
 
@@ -62,6 +46,22 @@ func (q *RedisQueue) FullName() string {
 	}
 
 	return laravelName
+}
+
+func (q *RedisQueue) GetQueueType() string {
+	return q.queueType
+}
+
+func (q *RedisQueue) SetQueueType(queueType string) {
+	q.queueType = queueType
+}
+
+func (q *RedisQueue) GetCurrentJobsCount() int64 {
+	return q.queueItem.Jobs
+}
+
+func (q *RedisQueue) SetCurrentJobsCount(count int64) {
+	q.queueItem.Jobs = count
 }
 
 func (q *RedisQueue) laravelQueueNameSplit() ([]string, int) {


### PR DESCRIPTION
The full name of the queue should be used instead of the short versionl

Full name is the name used by Laravel. It adds `queue` prefix to all queues managed by the framework.