### PR TITLE
Add initial docker-compose infrastructure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.7"
+services:
+  redis:
+    image: redis:5.0-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    restart: always
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    container_name: redis-commander
+    ports:
+      - "8081:8081"
+    restart: always
+    depends_on:
+      - redis
+    environment:
+      REDIS_HOSTS: "host.docker.internal"


### PR DESCRIPTION
In order to test the exporter using a real Redis service, this PR adds the docker infrastructure for:

- Redis service
- [Redis Commander](https://github.com/joeferner/redis-commander) - Admin and Dashboard