### PR TITLE
Add metrics publisher and consumers

### DIFF
--- a/pkg/consumer/consumer.go
+++ b/pkg/consumer/consumer.go
@@ -1,0 +1,7 @@
+package consumer
+
+import "github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+
+type Consumer interface {
+	Process(metrics []metric.Metric)
+}

--- a/pkg/consumer/log.go
+++ b/pkg/consumer/log.go
@@ -1,4 +1,4 @@
-package forwarder
+package consumer
 
 import (
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
@@ -8,7 +8,7 @@ import (
 type Log struct {
 }
 
-func (s *Log) Forward(metrics []metric.Metric) {
+func (l *Log) Process(metrics []metric.Metric) {
 	for _, m := range metrics {
 		log.Printf("%s %v", m.Name, m.Value)
 	}

--- a/pkg/consumer/stdout.go
+++ b/pkg/consumer/stdout.go
@@ -1,4 +1,4 @@
-package forwarder
+package consumer
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 type Stdout struct {
 }
 
-func (s *Stdout) Forward(metrics []metric.Metric) {
+func (s *Stdout) Process(metrics []metric.Metric) {
 	for _, m := range metrics {
 		fmt.Println(m.Name, m.Value)
 	}

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -1,0 +1,28 @@
+package publisher
+
+import (
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+)
+
+type MetricsPublisher struct {
+	consumers []consumer.Consumer
+}
+
+func (p *MetricsPublisher) SubscribeConsumers(consumer ...consumer.Consumer) {
+	if consumer == nil {
+		return
+	}
+
+	p.consumers = append(p.consumers, consumer...)
+}
+
+func (p *MetricsPublisher) Publish(metrics []metric.Metric) {
+	if len(metrics) == 0 {
+		return
+	}
+
+	for _, c := range p.consumers {
+		c.Process(metrics)
+	}
+}

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -1,0 +1,162 @@
+package publisher
+
+import (
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type fakeConsumer struct {
+	mock.Mock
+}
+
+func (c *fakeConsumer) Process(metrics []metric.Metric) {
+	c.Called(metrics)
+}
+
+func Test_Publisher_Should_Not_Notify_Consumers_When_Metrics_Are_NilOrEmpty(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		metrics         []metric.Metric
+		metricsConsumer *fakeConsumer
+		expected        bool
+	}{
+		{
+			desc:            "Metrics are nil",
+			metrics:         nil,
+			metricsConsumer: new(fakeConsumer),
+			expected:        true,
+		},
+		{
+			desc:            "Metrics are empty",
+			metrics:         []metric.Metric{},
+			metricsConsumer: new(fakeConsumer),
+			expected:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			publisher := new(MetricsPublisher)
+
+			publisher.SubscribeConsumers(tc.metricsConsumer)
+			tc.metricsConsumer.On("Process", tc.metrics)
+
+			publisher.Publish(tc.metrics)
+
+			notCalled := tc.metricsConsumer.AssertNotCalled(t, "Process")
+			assert.Equal(t, tc.expected, notCalled)
+		})
+	}
+}
+
+func Test_Publisher_Should_Notify_Consumers_When_Metrics_Are_Present(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		metrics  []metric.Metric
+		expected bool
+	}{
+		{
+			desc: "Single metric",
+			metrics: []metric.Metric{
+				{
+					Name:  "queue1",
+					Value: 1,
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "Multiple metrics",
+			metrics: []metric.Metric{
+				{
+					Name:  "queue1",
+					Value: 1,
+				},
+				{
+					Name:  "queue2",
+					Value: 2,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			publisher := new(MetricsPublisher)
+			metricsConsumer := new(fakeConsumer)
+
+			metricsConsumer.On("Process", tc.metrics)
+
+			publisher.SubscribeConsumers(metricsConsumer)
+			publisher.Publish(tc.metrics)
+
+			notCalled := metricsConsumer.AssertCalled(t, "Process", tc.metrics)
+			assert.Equal(t, tc.expected, notCalled)
+		})
+	}
+}
+
+func Test_Publisher_Should_Subscribe_Consumers(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		metricsConsumers []consumer.Consumer
+		expected         int
+	}{
+		{
+			desc: "Single metrics consumer",
+			metricsConsumers: []consumer.Consumer{
+				new(fakeConsumer),
+			},
+			expected: 1,
+		},
+		{
+			desc: "Multiple metrics consumers",
+			metricsConsumers: []consumer.Consumer{
+				new(fakeConsumer),
+				new(fakeConsumer),
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			publisher := new(MetricsPublisher)
+			publisher.SubscribeConsumers(tc.metricsConsumers...)
+
+			assert.Equal(t, tc.expected, len(publisher.consumers))
+		})
+	}
+}
+
+func Test_Publisher_Should_Not_Subscribe_Consumers(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		metricsConsumers []consumer.Consumer
+		expected         int
+	}{
+		{
+			desc:             "Empty metrics consumers",
+			metricsConsumers: []consumer.Consumer{},
+			expected:         0,
+		},
+		{
+			desc:             "Nil metrics consumers",
+			metricsConsumers: nil,
+			expected:         0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			publisher := new(MetricsPublisher)
+			publisher.SubscribeConsumers(tc.metricsConsumers...)
+
+			assert.Equal(t, tc.expected, len(publisher.consumers))
+		})
+	}
+}


### PR DESCRIPTION
This PR aims to add the infrastructure that will support publishers/consumers model.

A publisher is responsible for broadcasting and publishing the collected metrics across the list of its subscribed consumers. At this point, there are only 2 types of consumers implemented.

- STDOUT: outputs raw metrics format. 
`queue_name_1: 20`

- Log: output contains additional timestamp information. 
`2019/08/08 17:18:52 queue_name_1 20`

Future PRs will add extra options in terms of consumers and formatters. The same model can be used by different kind of consumers that target external services. I.e: statsD, Datadog, APIs, etc.