### PR TITLE
Add StatsD consumer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/DataDog/datadog-go"
+  packages = ["statsd"]
+  revision = "8a13fa761f51039f900738876f2837198fba804f"
+  version = "v2.2.0"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
@@ -41,6 +47,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d87170fa02c500498978db289bc48281e6747acd86e253ab94e3650699fa66dc"
+  inputs-digest = "79e7b66e8afb85e45e96d2ca10486893e3234a05cbdaebf964404a63f2624a51"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/laravel-queues-exporter/laravel-queues-exporter.go
+++ b/cmd/laravel-queues-exporter/laravel-queues-exporter.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/statsd"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/stdout"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/exporter/redis"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/publisher"
@@ -44,9 +46,9 @@ func main() {
 	exporter.Run(collected)
 
 	metricsPublisher := new(publisher.MetricsPublisher)
-	stdoutConsumer := new(consumer.Stdout)
-	logConsumer := new(consumer.Log)
-	metricsPublisher.SubscribeConsumers(stdoutConsumer, logConsumer)
+	stdoutConsumer := stdout.New()
+	statsdConsumer := statsd.New(appConfig)
+	metricsPublisher.SubscribeConsumers(stdoutConsumer, statsdConsumer)
 
 	for {
 		select {
@@ -71,7 +73,7 @@ func getConfig() *config.AppConfig {
 	flag.StringVar(&appConfig.RedisHost, "redis-host", config.GetEnv("REDIS_HOST", "127.0.0.1"), "Redis host where queues are stored")
 	flag.StringVar(&appConfig.RedisPort, "redis-port", config.GetEnv("REDIS_PORT", "6379"), "Redis target port open for connections")
 	flag.IntVar(&appConfig.RedisDB, "redis-db", config.GetEnvInt("REDIS_DB", 0), "Redis DB used by Laravel")
-	flag.StringVar(&appConfig.StatsDHost, "statsd-host", config.GetEnv("STATSD_HOST", "127.0.0.1"), "StatsD target to where metrics must be sent")
+	flag.StringVar(&appConfig.StatsDHost, "statsd-host", config.GetEnv("STATSD_HOST", "0.0.0.0"), "StatsD target to where metrics must be sent")
 	flag.StringVar(&appConfig.StatsDPort, "statsd-port", config.GetEnv("STATSD_PORT", "8125"), "StatsD target port open for connections")
 	flag.StringVar(&appConfig.MetricsPrefix, "metrics-prefix", config.GetEnv("METRICS_PREFIX", "exporter"), "Prefix to be added to every metric")
 	flag.IntVar(&appConfig.CollectInterval, "collect-interval", config.GetEnvInt("SCAN_INTERVAL", 60), "Interval in seconds between each metrics collect")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,21 @@ services:
     container_name: redis-commander
     ports:
       - "8081:8081"
+    volumes:
+      - redis-data:/data
     restart: always
     depends_on:
       - redis
     environment:
       REDIS_HOSTS: "host.docker.internal"
+  statsd:
+    image: statsd/statsd
+    container_name: statsd
+    ports:
+      - 8125:8125/udp
+    restart: always
+    volumes:
+      - ./hack/config.js:/usr/src/app/config.js
+
+volumes:
+  redis-data:

--- a/hack/config.js
+++ b/hack/config.js
@@ -1,0 +1,127 @@
+/*
+Graphite Required Variable:
+
+(Leave this unset to avoid sending stats to Graphite.
+ Set debug flag and leave this unset to run in 'dry' debug mode -
+ useful for testing statsd clients without a Graphite server.)
+
+  graphiteHost:     hostname or IP of Graphite server
+
+Optional Variables:
+
+  graphitePort:     port for the graphite text collector [default: 2003]
+  graphitePicklePort: port for the graphite pickle collector [default: 2004]
+  graphiteProtocol: either 'text' or 'pickle' [default: 'text']
+  backends:         an array of backends to load. Each backend must exist
+                    by name in the directory backends/. If not specified,
+                    the default graphite backend will be loaded.
+                    * example for console and graphite:
+                    [ "./backends/console", "./backends/graphite" ]
+
+  servers:          an array of server configurations.
+                    If not specified, the server, address,
+                    address_ipv6, and port top-level configuration
+                    options are used to configure a single server for
+                    backwards-compatibility
+                    Each server configuration supports the following keys:
+    server:         the server to load. The server must exist by name in the directory
+                    servers/. If not specified, the default udp server will be loaded.
+                    * example for tcp server:
+                    "./servers/tcp"
+    address:        address to listen on [default: 0.0.0.0]
+    address_ipv6:   defines if the address is an IPv4 or IPv6 address [true or false, default: false]
+    port:           port to listen for messages on [default: 8125]
+    socket:         (only for tcp servers) path to unix domain socket which will be used to receive
+                    metrics [default: undefinded]
+    socket_mod:     (only for tcp servers) file mode which should be applied to unix domain socket, relevant
+                    only if socket option is used [default: undefined]
+
+  debug:            debug flag [default: false]
+  mgmt_address:     address to run the management TCP interface on
+                    [default: 0.0.0.0]
+  mgmt_port:        port to run the management TCP interface on [default: 8126]
+  title:            Allows for overriding the process title. [default: statsd]
+                    if set to false, will not override the process title and let the OS set it.
+                    The length of the title has to be less than or equal to the binary name + cli arguments
+                    NOTE: This does not work on Mac's with node versions prior to v0.10
+
+  healthStatus:     default health status to be returned and statsd process starts ['up' or 'down', default: 'up']
+  dumpMessages:     log all incoming messages
+  flushInterval:    interval (in ms) to flush metrics to each backend
+  percentThreshold: for time information, calculate the Nth percentile(s)
+                    (can be a single value or list of floating-point values)
+                    negative values mean to use "top" Nth percentile(s) values
+                    [%, default: 90]
+  flush_counts:     send stats_counts metrics [default: true]
+
+  keyFlush:         log the most frequently sent keys [object, default: undefined]
+    interval:       how often to log frequent keys [ms, default: 0]
+    percent:        percentage of frequent keys to log [%, default: 100]
+    log:            location of log file for frequent keys [default: STDOUT]
+  deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
+                    as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
+                    the previous value). Can be individually overriden. [default: false]
+  deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
+  deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
+  deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]
+  deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]
+  prefixStats:      prefix to use for the statsd statistics data for this running instance of statsd [default: statsd]
+                    applies to both legacy and new namespacing
+  keyNameSanitize:  sanitize all stat names on ingress [default: true]
+                    If disabled, it is up to the backends to sanitize keynames
+                    as appropriate per their storage requirements.
+
+  console:
+    prettyprint:    whether to prettyprint the console backend
+                    output [true or false, default: true]
+
+  log:              log settings [object, default: undefined]
+    backend:        where to log: stdout or syslog [string, default: stdout]
+    application:    name of the application for syslog [string, default: statsd]
+    level:          log level for [node-]syslog [string, default: LOG_INFO]
+
+  graphite:
+    legacyNamespace:  use the legacy namespace [default: true]
+    globalPrefix:     global prefix to use for sending stats to graphite [default: "stats"]
+    prefixCounter:    graphite prefix for counter metrics [default: "counters"]
+    prefixTimer:      graphite prefix for timer metrics [default: "timers"]
+    prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
+    prefixSet:        graphite prefix for set metrics [default: "sets"]
+    globalSuffix:     global suffix to use for sending stats to graphite [default: ""]
+                      This is particularly useful for sending per host stats by
+                      settings this value to: require('os').hostname().split('.')[0]
+
+  repeater:         an array of hashes of the for host: and port:
+                    that details other statsd servers to which the received
+                    packets should be "repeated" (duplicated to).
+                    e.g. [ { host: '10.10.10.10', port: 8125 },
+                           { host: 'observer', port: 88125 } ]
+
+  repeaterProtocol: whether to use udp4, udp6, or tcp for repeaters.
+                    ["udp4," "udp6", or "tcp" default: "udp4"]
+
+  histogram:        for timers, an array of mappings of strings (to match metrics) and
+                    corresponding ordered non-inclusive upper limits of bins.
+                    For all matching metrics, histograms are maintained over
+                    time by writing the frequencies for all bins.
+                    'inf' means infinity. A lower limit of 0 is assumed.
+                    default: [], meaning no histograms for any timer.
+                    First match wins.  examples:
+                    * histogram to only track render durations, with unequal
+                      class intervals and catchall for outliers:
+                      [ { metric: 'render', bins: [ 0.01, 0.1, 1, 10, 'inf'] } ]
+                    * histogram for all timers except 'foo' related,
+                      equal class interval and catchall for outliers:
+                     [ { metric: 'foo', bins: [] },
+                       { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
+
+  automaticConfigReload: whether to watch the config file and reload it when it
+                         changes. The default is true. Set this to false to disable.
+*/
+(function() {
+    return {
+        port: 8125,
+        dumpMessages: "true",
+        debug: "true",
+    };
+})()

--- a/pkg/consumer/log/log.go
+++ b/pkg/consumer/log/log.go
@@ -1,4 +1,4 @@
-package consumer
+package log
 
 import (
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"

--- a/pkg/consumer/statsd/statsd.go
+++ b/pkg/consumer/statsd/statsd.go
@@ -1,0 +1,36 @@
+package statsd
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+	"log"
+)
+
+type StatsD struct {
+	host          string
+	port          string
+	metricsPrefix string
+}
+
+func New(config *config.AppConfig) *StatsD {
+	return &StatsD{
+		host:          config.StatsDHost,
+		port:          config.StatsDPort,
+		metricsPrefix: config.MetricsPrefix,
+	}
+}
+
+func (s *StatsD) Process(metrics []metric.Metric) {
+	client, err := statsd.New(fmt.Sprintf("%s:%s", s.host, s.port))
+
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	for _, metric := range metrics {
+		err = client.Gauge(metric.WithPrefix(s.metricsPrefix), metric.ValueToFloat64(), []string{}, 1)
+	}
+}

--- a/pkg/consumer/stdout/stdout.go
+++ b/pkg/consumer/stdout/stdout.go
@@ -1,4 +1,4 @@
-package consumer
+package stdout
 
 import (
 	"fmt"
@@ -6,6 +6,10 @@ import (
 )
 
 type Stdout struct {
+}
+
+func New() *Stdout {
+	return new(Stdout)
 }
 
 func (s *Stdout) Process(metrics []metric.Metric) {

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -1,6 +1,20 @@
 package metric
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Metric struct {
 	Name  string
 	Value int64
+}
+
+func (m *Metric) WithPrefix(prefix string) string {
+	parsedName := strings.ReplaceAll(m.Name, ":", ".")
+	return fmt.Sprintf("%s.%s", prefix, parsedName)
+}
+
+func (m *Metric) ValueToFloat64() float64 {
+	return float64(m.Value)
 }


### PR DESCRIPTION
This PR add the StatsD consumer and a local infrastructure for running statsd server as part of the docker-compose services list.