### PR TITLE
Add Factory for Consumers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ type AppConfig struct {
 	MetricsPrefix   string
 	CollectInterval int
 	QueuesNames     string
+	ExportTo        string
 }
 
 func GetEnv(key, fallback string) string {

--- a/pkg/consumer/consumer.go
+++ b/pkg/consumer/consumer.go
@@ -1,7 +1,67 @@
 package consumer
 
-import "github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+import (
+	"errors"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
+	log_consumer "github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/log"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/statsd"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/stdout"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
+	"strings"
+)
 
 type Consumer interface {
 	Process(metrics []metric.Metric)
+}
+
+type ConsumerFactory struct {
+}
+
+var errorConsumersConfigIsEmpty = errors.New("The provided list of consumers from config is empty")
+var errorConsumerTypeNotRegistered = errors.New("Consumer type not registered")
+
+func BuildConsumersListFromConfig(appConfig *config.AppConfig) ([]Consumer, error) {
+	var consumers []Consumer
+	var err error
+
+	if len(appConfig.ExportTo) == 0 {
+		return nil, errorConsumersConfigIsEmpty
+	}
+
+	splitConsumers := splitFromConfig(appConfig.ExportTo)
+	factory := new(ConsumerFactory)
+
+	for _, consumerType := range splitConsumers {
+		consumer, err := factory.NewConsumer(appConfig, consumerType)
+		if err != nil {
+			return nil, err
+		}
+
+		consumers = append(consumers, consumer)
+	}
+
+	return consumers, err
+
+}
+
+func splitFromConfig(config string) []string {
+	return strings.Split(config, ",")
+}
+
+func (f *ConsumerFactory) NewConsumer(config *config.AppConfig, consumerType string) (Consumer, error) {
+	var consumer Consumer
+	var err error
+
+	switch consumerType {
+	case "stdout":
+		consumer, err = stdout.New(config)
+	case "statsd":
+		consumer, err = statsd.New(config)
+	case "log":
+		consumer, err = log_consumer.New(config)
+	default:
+		err = errorConsumerTypeNotRegistered
+	}
+
+	return consumer, err
 }

--- a/pkg/consumer/consumer_test.go
+++ b/pkg/consumer/consumer_test.go
@@ -1,0 +1,57 @@
+package consumer
+
+import (
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/log"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/statsd"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/consumer/stdout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func Test_Consumer_ShouldReturnStdoutConsumerGivenConfiguration(t *testing.T) {
+	appConfig := &config.AppConfig{
+		RedisHost:  "0.0.0.0",
+		RedisPort:  "6379",
+		RedisDB:    0,
+		StatsDHost: "0.0.0.0",
+		StatsDPort: "8125",
+	}
+
+	testCase := []struct {
+		desc         string
+		exportTo     string
+		consumerType interface{}
+		expected     bool
+	}{
+		{
+			desc:         "Return stdout consumer",
+			exportTo:     "stdout",
+			consumerType: reflect.TypeOf(&stdout.Stdout{}),
+			expected:     true,
+		},
+		{
+			desc:         "Return statsd consumer",
+			exportTo:     "statsd",
+			consumerType: reflect.TypeOf(&statsd.StatsD{}),
+			expected:     true,
+		},
+		{
+			desc:         "Return log consumer",
+			exportTo:     "log",
+			consumerType: reflect.TypeOf(&log.Log{}),
+			expected:     true,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.desc, func(t *testing.T) {
+			appConfig.ExportTo = tc.exportTo
+			consumer, err := BuildConsumersListFromConfig(appConfig)
+			require.Nil(t, err)
+			assert.Equal(t, tc.consumerType, reflect.TypeOf(consumer[0]))
+		})
+	}
+}

--- a/pkg/consumer/log/log.go
+++ b/pkg/consumer/log/log.go
@@ -1,11 +1,16 @@
 package log
 
 import (
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
 	"log"
 )
 
 type Log struct {
+}
+
+func New(config *config.AppConfig) (*Log, error) {
+	return &Log{}, nil
 }
 
 func (l *Log) Process(metrics []metric.Metric) {

--- a/pkg/consumer/statsd/statsd.go
+++ b/pkg/consumer/statsd/statsd.go
@@ -13,10 +13,12 @@ type StatsD struct {
 	port          string
 	metricsPrefix string
 	client        *statsd.Client
+	//TODO add init message
 }
 
 func New(config *config.AppConfig) (*StatsD, error) {
-	client, err := statsd.New(fmt.Sprintf("%s:%s", config.StatsDHost, config.StatsDPort))
+	conn := fmt.Sprintf("%s:%s", config.StatsDHost, config.StatsDPort)
+	client, err := statsd.New(conn)
 
 	if err != nil {
 		log.Println(err)

--- a/pkg/consumer/stdout/stdout.go
+++ b/pkg/consumer/stdout/stdout.go
@@ -2,14 +2,15 @@ package stdout
 
 import (
 	"fmt"
+	"github.com/danieloliveira079/laravel-queues-exporter/pkg/config"
 	"github.com/danieloliveira079/laravel-queues-exporter/pkg/metric"
 )
 
 type Stdout struct {
 }
 
-func New() *Stdout {
-	return new(Stdout)
+func New(config *config.AppConfig) (*Stdout, error) {
+	return new(Stdout), nil
 }
 
 func (s *Stdout) Process(metrics []metric.Metric) {


### PR DESCRIPTION
This PR adds the Factory that will create consumers based on the configuration present on the AppConfig named ExportTo or flag export-to.

That should be a list of possible consumers types. Those values can be combined using a comma.

Possible values: stdout, log, statsd.