### PR TITLE
Check when queue name is empty

### DIFF
--- a/pkg/consumer/statsd/statsd.go
+++ b/pkg/consumer/statsd/statsd.go
@@ -34,10 +34,12 @@ func New(config *config.AppConfig) (*StatsD, error) {
 }
 
 func (s *StatsD) Process(metrics []metric.Metric) {
-	for _, metric := range metrics {
-		err := s.client.Gauge(metric.WithPrefix(s.metricsPrefix), metric.ValueToFloat64(), []string{}, 1)
-		if err != nil {
-			log.Println(err)
+	for _, m := range metrics {
+		if len(m.Name) > 0 {
+			err := s.client.Gauge(m.WithPrefix(s.metricsPrefix), m.ValueToFloat64(), []string{}, 1)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 	}
 }

--- a/pkg/consumer/stdout/stdout.go
+++ b/pkg/consumer/stdout/stdout.go
@@ -15,6 +15,8 @@ func New(config *config.AppConfig) (*Stdout, error) {
 
 func (s *Stdout) Process(metrics []metric.Metric) {
 	for _, m := range metrics {
-		fmt.Println(m.Name, m.Value)
+		if len(m.Name) > 0 {
+			fmt.Println(m.Name, m.Value)
+		}
 	}
 }


### PR DESCRIPTION
Consumers should not print queue names and it is empty